### PR TITLE
Inner prod testcase [FAIL] 

### DIFF
--- a/autodiff_test.py
+++ b/autodiff_test.py
@@ -407,3 +407,24 @@ def test_einsum():
         assert T.array_equal(y_val, expected_yval)
         assert T.array_equal(grad_x2_val, expected_grad_x2_val)
         assert T.array_equal(grad_x3_val, expected_grad_x3_val)
+
+
+def test_inner_product():
+    for datatype in BACKEND_TYPES:
+        T.set_backend(datatype)
+        x = ad.Variable(name="x")
+        x_inner = ad.einsum('k,k->', x, x)
+
+        grad_x = ad.gradients(x_inner, [x])
+
+        executor = ad.Executor([x_inner, grad_x])
+        x_val = T.tensor([[1, 2]])  # 1x2
+
+        y_val, grad_x_val = executor.run(feed_dict={x: x_val})
+
+        expected_yval = T.dot(x_val, x_val)
+        expected_grad_x_val = 2 * x_val
+
+        assert isinstance(y, ad.Node)
+        assert T.array_equal(y_val, expected_yval)
+        assert T.array_equal(grad_x_val, expected_grad_x_val)


### PR DESCRIPTION
This PR goes after the BACKEND_TYPE refactor: 

Error message: 

Traceback (most recent call last):
  File "/home/jiayuye/anaconda3/lib/python3.6/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/jiayuye/workspace/Auto-Differentiation/autodiff_test.py", line 424, in test_inner_product
    y_val, grad_x_val = executor.run(feed_dict={x: x_val})
  File "/home/jiayuye/workspace/Auto-Differentiation/autodiff.py", line 488, in run
    topo_order = find_topo_sort(self.eval_node_list)
  File "/home/jiayuye/workspace/Auto-Differentiation/utils.py", line 29, in find_topo_sort
    topo_sort_dfs(node, visited, topo_order)
  File "/home/jiayuye/workspace/Auto-Differentiation/utils.py", line 36, in topo_sort_dfs
    if node in visited:
TypeError: unhashable type: 'list'
