### PR TITLE
fix the error of "float type has no shape with ctf backend

### DIFF
--- a/autodiff.py
+++ b/autodiff.py
@@ -517,7 +517,7 @@ class ZerosLikeOp(Op):
 
     def compute(self, node, input_vals):
         """Returns zeros_like of the same shape as input."""
-        return T.zeros(input_vals[0].shape)
+        return T.zeros_like(input_vals[0])
 
     def vjp(self, node, output_grad):
         return [zeroslike(node.inputs[0])]
@@ -538,7 +538,7 @@ class OnesLikeOp(Op):
 
     def compute(self, node, input_vals):
         """Returns ones_like of the same shape as input."""
-        return T.ones(input_vals[0].shape)
+        return T.ones_like(input_vals[0])
 
     def vjp(self, node, output_grad):
         return [zeroslike(node.inputs[0])]

--- a/backend/ctf_backend.py
+++ b/backend/ctf_backend.py
@@ -24,6 +24,8 @@ class CTFBackend(Backend):
 
     @staticmethod
     def shape(tensor):
+        if isinstance(tensor, float):
+            return ()
         return tensor.shape
 
     @staticmethod
@@ -72,12 +74,15 @@ class CTFBackend(Backend):
 
     @staticmethod
     def ones_like(tensor):
-        return ctf.ones(tensor.shape)
+        return ctf.ones(CTFBackend.shape(tensor))
+
+    @staticmethod
+    def zeros_like(tensor):
+        return ctf.zeros(CTFBackend.shape(tensor))
 
 
 for name in ['reshape', 'transpose', 'copy', 'qr', 'ones', 'zeros',
-             'zeros_like', 'eye', 'abs', 'dot', 'einsum',
-             'sum']:
+             'eye', 'abs', 'dot', 'einsum', 'sum']:
     CTFBackend.register_method(name, getattr(ctf, name))
 
 for name in ['random', 'seed']:


### PR DESCRIPTION
run `nosetests -v tests/*.py` under master branch will produce error:

======================================================================
ERROR: autodiff_test.test_inner_product_einsum
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/anaconda2/envs/py36/lib/python3.6/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/Users/linjian/Documents/auto-diff/tests/autodiff_test.py", line 561, in test_inner_product_einsum
    y_val, grad_x_val = executor.run(feed_dict={x: x_val})
  File "/Users/linjian/Documents/auto-diff/autodiff.py", line 618, in run
    result = node.op.compute(node, input_vals)
  File "/Users/linjian/Documents/auto-diff/autodiff.py", line 544, in compute
    return T.ones(input_vals[0].shape)
AttributeError: 'float' object has no attribute 'shape'

this pr fixes this error.