### PR TITLE
Let rewrite einsum expr handle the case where input node order are different. 

### DIFF
--- a/graph_ops/graph_transformer.py
+++ b/graph_ops/graph_transformer.py
@@ -154,6 +154,7 @@ def rewrite_einsum_expr(einsum_node):
     assert (isinstance(einsum_node, ad.EinsumNode))
     input_nodes = einsum_node.inputs
     assert len(input_nodes) == len(set(input_nodes))
+    input_nodes = sorted(input_nodes, key=lambda input_node: input_node.name)
 
     # TODO: Get all the einsum nodes in the computation graph.
     # Note that the order doesn't matter!
@@ -180,6 +181,7 @@ def rewrite_einsum_expr(einsum_node):
     new_input_subs = [node.subscripts for node in input_nodes]
     new_subscripts = ",".join(new_input_subs) + "->" + einsum_node.subscripts
     einsum_node.einsum_subscripts = new_subscripts
+    einsum_node.set_inputs(input_nodes)
     logger.info(f"Rewrite to new subscript: {new_subscripts}")
 
 

--- a/tests/graph_transforms_test.py
+++ b/tests/graph_transforms_test.py
@@ -337,3 +337,18 @@ def test_rewrite_expr():
     rewrite_einsum_expr(x)
     rewrite_einsum_expr(y)
     assert x.einsum_subscripts == y.einsum_subscripts
+
+
+def test_einsum_equal():
+
+    a1 = ad.Variable(name="a1", shape=[3, 2])
+    a2 = ad.Variable(name="a2", shape=[2, 3])
+
+    x = ad.einsum('ik,kj->ij', a1, a2)
+    y = ad.einsum('ml,sm->sl', a2, a1)
+
+    rewrite_einsum_expr(x)
+    rewrite_einsum_expr(y)
+
+    assert x.einsum_subscripts == y.einsum_subscripts
+    assert x.inputs == y.inputs


### PR DESCRIPTION
Overflow.