### PR TITLE
potential need for new API to construct graph based on einsum intermediate

### DIFF
--- a/examples/tucker.py
+++ b/examples/tucker.py
@@ -1,6 +1,7 @@
 import autodiff as ad
 import backend as T
 from utils import CharacterGetter
+from tensors.synthetic_tensors import init_rand_tucker
 
 BACKEND_TYPES = ['numpy']
 
@@ -49,6 +50,43 @@ def tucker_graph(dim, size, rank):
     residual = output - X
     loss = ad.einsum(f"{X_subscripts},{X_subscripts}->", residual, residual)
     return A_list, core, X, loss, residual
+
+
+def tucker_als(dim, size, rank, num_iter, input_val=[]):
+    A_list, core, X, loss, residual = tucker_graph(dim, size, rank)
+
+    executors = []
+
+    for i in range(dim):
+
+        core_A = ad.intermediate(loss, {core, A_list[i]})
+        hes = ad.hessian(loss, core_A)
+        grad = ad.gradients(loss, core_A)
+
+        new_core_A = core_A - ad.tensordot(
+            ad.tensorinv(hes), grad,
+            [[i + dim for i in range(dim)], [i for i in range(dim)]])
+
+        executor = ad.Executor([loss, new_core_A])
+        executors.append(executor)
+
+    if input_val == []:
+        A_list_val, core_val, X_val = init_rand_tucker(dim, size, rank)
+    else:
+        A_list_val, core_val, X_val = input_val
+
+    for iter in range(num_iter):
+        # als iterations
+        for i in range(dim):
+
+            loss_val, new_core_A_val = executors[i].run(feed_dict={  #TODO
+            })
+
+            # update core and A_i
+
+        print(f'At iteration {iter} the loss is: {loss_val}')
+
+    return A_val, B_val, C_val
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Open for discussion: we need a new API to construct graph based on einsum intermediate. I use the Tucker ALS to show the use case, and this one will also be used in DMRG.

For Tucker ALS, each step is equivalent to a Newton's step on the intermediate of the core tensor and each factor matrix. After this step is done, SVD will be used to update core tensor and factor matrix (what will be done at line 85). It can be seen as a hierarchical update. 

What we need is a function to construct the intermediate (line 62), and calculate its hessian and grad (line 63-64). 

The question is how to properly implement ad.intermediate. One way is to find the intermediate, and internally doing an inplace update to loss. In that way, the line 63 and 64 can be properly executed. However, this implementation is error prone: if I execute the code like
```python
        core_A_0 = ad.intermediate(loss, {core, A_list[0]})
        core_A_1 = ad.intermediate(loss, {core, A_list[1]})
        hes_0 = ad.hessian(loss, core_A_0)
        hes_1 = ad.hessian(loss, core_A_1)
```
then hes_0 will not be calculated correctly because after line 2 core_A_0 will potentially not be the input of loss.

We can also let the intermediate function build a new graph also for loss. So the user code can be like 
```python
        core_A, loss_copy = ad.intermediate(loss, {core, A_list[i]})
        hes = ad.hessian(loss_copy, core_A)
        grad = ad.gradients(loss_copy, core_A)
```
but seems the API is  a bit clumsy. 

New ideas are welcome on this problem.