### PR TITLE
Add code coverage tool for the project. 

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -50,6 +50,8 @@ jobs:
     - name: Generate pytest coverage
       run: |
         pip install pytest-cov
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:"$PWD/install/lib"
+        export PYTHONPATH=$PWD
         pytest --ignore=ctf --cov=./ --cov-report=xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1


### PR DESCRIPTION
[Need to change the CODECOV_TOKEN]
Before the merge, there are several things: 
1. Can you check if https://codecov.io/gh/ByzanTine/Auto-Differentiation/src/82d889b50fdf6aba43ff699046e14c2395b6f3b8/graph_ops/graph_inv_optimizer.py is not 404.

2. You would need to setup account in codecov.io, signup account and activate your Auto-diff repo. It should be straightforward, let if know if there are issues. Then there will be a upload token within the setting tab.

3. you would need to setup CODECOV_TOKEN as a secret in your Repo->Settings->Secret, let me know if you couldn't find it. 