### PR TITLE
fix a bug in get_common_ancester

### DIFF
--- a/graph_ops/graph_generator.py
+++ b/graph_ops/graph_generator.py
@@ -1,4 +1,4 @@
-from utils import get_all_einsum_descendants, get_all_inputs, find_topo_sort, get_tree
+from utils import get_all_einsum_descendants, get_all_inputs, find_topo_sort, get_all_nodes
 
 import autodiff as ad
 import copy
@@ -106,7 +106,9 @@ def get_common_ancestor(root, leaves, in_node):
     for node in topo_order_list:
         # We want to get the smallest subtree whose inputs contain all the in_node(s).
         if isinstance(node, ad.EinsumNode):
-            subtree_leaves = [n for n in get_tree(node) if n in leaves]
+            subtree_leaves = [
+                n for n in get_all_nodes([node], leaves) if n in leaves
+            ]
             num_in_nodes_subtree = len(
                 list(filter(lambda n: n is in_node, subtree_leaves)))
             if num_in_nodes == num_in_nodes_subtree:
@@ -149,7 +151,8 @@ def generate_optimal_tree_w_constraint(einsum_node, contract_order):
                                                 contract_order[i])
 
         first_contract_inputs = [
-            n for n in get_tree(opt_contract_tree)
+            n
+            for n in get_all_nodes([opt_contract_tree], splitted_einsum.inputs)
             if n in splitted_einsum.inputs
         ]
 

--- a/tests/graph_generator_test.py
+++ b/tests/graph_generator_test.py
@@ -150,6 +150,14 @@ def test_get_common_ancester_intermediate_leaves():
     assert ancester == d
 
 
+def test_get_common_ancester_dup():
+    a = ad.Variable(name="a", shape=[2, 2])
+    aa = ad.einsum("ab,bc->ac", a, a)
+    out = ad.einsum("ab,bc->ac", aa, a)
+    ancester = get_common_ancestor(out, [aa, a], a)
+    assert ancester == out
+
+
 def test_split_einsum_dup():
     for datatype in BACKEND_TYPES:
 

--- a/utils.py
+++ b/utils.py
@@ -70,11 +70,18 @@ def get_all_inputs(out):
     return all_inputs
 
 
-def get_tree(root):
+def get_all_nodes(sinks, sources=[]):
     """
     Get all the nodes in the tree defined by root node.
+    Args:
+        sinks: A list of nodes defines the sink.
+        sources: Stop expanding at provided sources.
     """
-    return [pnode.node for pnode in find_topo_sort_p([PseudoNode(root)])]
+    return [
+        pnode.node
+        for pnode in find_topo_sort_p([PseudoNode(sink)
+                                       for sink in sinks], sources)
+    ]
 
 
 def sympy_simplify(out, inputs):


### PR DESCRIPTION
The changes are similar to #198 , here change get_tree to get_all_nodes to fix a bug in get_common_ancester when several dup nodes are involved