### PR TITLE
exclude ctf from running flake8

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -20,7 +20,7 @@ jobs:
         sudo apt-get install mpich libblas-dev
     - name: Instal CTF
       run: |
-        git clone https://github.com/LinjianMa/ctf.git
+        git clone https://github.com/cyclops-community/ctf.git
         mkdir install install/include install/lib
         cd ctf
         # Download scalapack.
@@ -37,9 +37,9 @@ jobs:
       run: |
         pip install flake8
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 . --exclude=ctf/* --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 . --exclude=ctf/* --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
         pip install pytest


### PR DESCRIPTION
Newest ctf/lib_python has some external libs that will make flake8 fail.