### PR TITLE
Avoid getting permutation set in collapse_sym to save time

### DIFF
--- a/graph_ops/graph_dedup.py
+++ b/graph_ops/graph_dedup.py
@@ -183,7 +183,7 @@ def collapse_symmetric_expr(A, B):
         return
 
     if equivalent_list_dims_w_permutation(contracted_set_A, contracted_set_B):
-        # One of the permutations is equivalent
+        # One of the permutations is equivalent.
         A.einsum_subscripts = B.einsum_subscripts
         A.set_inputs(B.inputs)
         return


### PR DESCRIPTION
itertools.permutations will be too slow and the output will be too large when einsum is long.