### PR TITLE
make pt.tensor the primitive operating type rather than numpy array in TacoBackend

### DIFF
--- a/autodiff.py
+++ b/autodiff.py
@@ -595,9 +595,9 @@ class MulNode(OpNode):
         if self.scalar_A is False and self.scalar_B is False:
             assert input_vals[0].shape == input_vals[1].shape
         if self.scalar_A:
-            assert input_vals[0].shape == ()
+            assert len(input_vals[0].shape) == 0
         if self.scalar_B:
-            assert input_vals[1].shape == ()
+            assert len(input_vals[1].shape) == 0
         return input_vals[0] * input_vals[1]
 
     def transposed_vjp(self, output_grad):

--- a/tests/autodiff_test.py
+++ b/tests/autodiff_test.py
@@ -751,7 +751,7 @@ def test_inner_product_hvp(backendopt):
             v: v_val
         })
 
-        expected_yval = T.sum(T.transpose(x_val) @ x_val)
+        expected_yval = T.sum(T.dot(T.transpose(x_val), x_val))
         expected_grad_x_val = 2 * x_val
         expected_hv_val = 2 * v_val
 
@@ -782,12 +782,13 @@ def test_hvp1(backendopt):
             v: v_val
         })
 
-        expected_yval = T.transpose(x_val) @ H_val @ x_val
-        expected_grad_x_val = 2 * H_val @ x_val
+        Hx = T.dot(H_val, x_val)
+        expected_yval = T.sum(T.dot(T.transpose(x_val), Hx))
+        expected_grad_x_val = 2 * Hx
         expected_hv_val = T.tensor([[4.], [8.], [12.]])
 
         assert isinstance(y, ad.Node)
-        assert T.array_equal(y_val, expected_yval[0][0])
+        assert T.array_equal(y_val, expected_yval)
         assert T.array_equal(grad_x_val, expected_grad_x_val)
         assert T.array_equal(Hv_val, expected_hv_val)
 
@@ -814,8 +815,9 @@ def test_hvp2(backendopt):
             H: H_val,
             v: v_val
         })
-        expected_yval = T.sum(T.transpose(x_val) @ H_val @ x_val)
-        expected_grad_x_val = 2 * H_val @ x_val
+        Hx = T.dot(H_val, x_val)
+        expected_yval = T.sum(T.dot(T.transpose(x_val), Hx))
+        expected_grad_x_val = 2 * Hx
         expected_hv_val = T.tensor([[4.], [8.], [12.]])
 
         assert isinstance(y, ad.Node)


### PR DESCRIPTION
Taco is rather slowish here, for autodiff_test, it takes 16s vs 1s for numpy on my laptop...

Pending CI running, do not merge yet.