### PR TITLE
Restrict the input node shape to be list type

### DIFF
--- a/autohoot/autodiff.py
+++ b/autohoot/autodiff.py
@@ -198,7 +198,10 @@ class ConstantNode(Node):
     def __init__(self, name, shape=None, value=None):
         super().__init__()
         self.name = name
-        self.shape = shape
+        if shape is None:
+            self.shape = shape
+        else:
+            self.shape = list(shape)
         self.value = value
 
     def compute(self):
@@ -293,7 +296,7 @@ class VariableNode(Node):
         """
         super().__init__()
         self.name = name
-        self.shape = shape
+        self.shape = list(shape)
         assert shape is not None
         self.symmetry = symmetry
         assert isinstance(format, (DenseFormat, SparseFormat))


### PR DESCRIPTION
When we construct the graph (e.g. Variable(x, shape=[2,3])) in Julia, the shape list will be transferred to NumPy array in python and incur some errors later.